### PR TITLE
feat(20): Avatar.jsx. 컴포넌트 제작 및 global.jsx 수정

### DIFF
--- a/src/components/Avatar.jsx
+++ b/src/components/Avatar.jsx
@@ -1,0 +1,36 @@
+/** @jsxImportSource @emotion/react */
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "@emotion/styled";
+
+const AvatarWrapper = styled.div`
+  width: 100%; /* 부모 요소의 너비에 따라 너비가 결정됨 */
+  aspect-ratio: 1 / 1; /* 1:1 비율로 높이를 너비와 동일하게 설정 */
+  border-radius: 50%; /* 원형 모양 */
+  overflow: hidden;
+  border: 1.31px solid #f96868; /* 테두리 색상과 두께 */
+  position: relative; /* 자식 요소의 절대 위치를 위해 설정 */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const AvatarImage = styled.img`
+  width: 92%;
+  height: 92%;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+function Avatar({ imageUrl }) {
+  return (
+    <AvatarWrapper>
+      <AvatarImage src={imageUrl} alt="Avatar" />
+    </AvatarWrapper>
+  );
+}
+
+Avatar.propTypes = {
+  imageUrl: PropTypes.string.isRequired, // 이미지 URL을 문자열로 받습니다.
+};
+
+export default Avatar;

--- a/src/styles/global.jsx
+++ b/src/styles/global.jsx
@@ -20,6 +20,12 @@ const GlobalStyles = () => (
     </Helmet>
     <Global
       styles={css`
+        *,
+        *::before,
+        *::after {
+          box-sizing: border-box;
+        }
+          
         html,
         body,
         div,
@@ -152,7 +158,7 @@ const GlobalStyles = () => (
           --gray-200: #828282;
           --gray-blue: #8c92ab;
           --gray-100: #a3a5a8;
-          --white: F7F7F8;
+          --white: #F7F7F8;
           --coralpink: #f96d69;
           --hotpink: #fe5493;
           }


### PR DESCRIPTION

## 🧩 #20  <!-- 이슈 번호 입력 -->
- [feature/components/Avatar #20 ]

  <br/>

## 🔎 작업 내용

- 아바타 UI 구현
- 글로벌.jsx  `box-sizing: border-box;` 적용
- 사용방법
  - `<Avatar imageUrl={url의 값} />`
  - 예제) 
![스크린샷 2024-08-29 165334](https://github.com/user-attachments/assets/8c204f82-7c91-4442-9154-2c1cc2baf150)
  - 사용하실때, 아바타 상위(부모)의 width 값을 따라가도록 코드를 작성했습니다.
  - 즉, 반응형 디자인 시 저 아바타를 감싸고 있는 상위 태그의 width값에 따라 알아서 아바타 값도 조절됩니다.

  <br/>

## 이미지 첨부
- 위에서 언급한 상위태그의 `width`를 각각 `120px, 80px` 준 예시입니다.
<img src="https://github.com/user-attachments/assets/06894971-1fde-4f58-b6fb-84deeca56ddc" width="50%" height="50%"/>
<br/>


## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
