### PR TITLE
feat(28): Jotai 설치, 충전 모달창 제작, 크레딧 부족 경고 모달창 제작, 박스버튼 프롭 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.7.5",
         "framer-motion": "^11.3.30",
+        "jotai": "^2.9.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet": "^6.1.0",
@@ -12306,6 +12307,26 @@
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.9.3.tgz",
+      "integrity": "sha512-IqMWKoXuEzWSShjd9UhalNsRGbdju5G2FrqNLQJT+Ih6p41VNYe2sav5hnwQx4HJr25jq9wRqvGSWGviGG6Gjw==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.7.5",
     "framer-motion": "^11.3.30",
+    "jotai": "^2.9.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet": "^6.1.0",

--- a/src/assets/icon/white_credit_icon.svg
+++ b/src/assets/icon/white_credit_icon.svg
@@ -1,0 +1,22 @@
+<svg width="21" height="25" viewBox="0 0 21 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.875 12.5L10.5 10.0625L12.125 12.5L10.5 14.9375L8.875 12.5Z" fill="white"/>
+<g filter="url(#filter0_d_8433_1217)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10.5 6L14.9688 12.3977L10.5 18.7729L6.03125 12.3977L10.5 6ZM7.00938 12.3969L10.5 17.3766L13.9906 12.3969L10.5 7.39952L7.00938 12.3969Z" fill="url(#paint0_linear_8433_1217)"/>
+</g>
+<defs>
+<filter id="filter0_d_8433_1217" x="0.03125" y="0" width="20.9375" height="24.7729" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="3"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.666667 0 0 0 0 0.666667 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_8433_1217"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_8433_1217" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_8433_1217" x1="10.5" y1="6" x2="10.5" y2="18.7729" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/components/BoxButton.jsx
+++ b/src/components/BoxButton.jsx
@@ -45,7 +45,7 @@ const ButtonWrapper = styled.button`
   }
 `;
 
-function BoxButton({ size, children, icon, disabled }) {
+function BoxButton({ size, children, icon, disabled, onClick }) {
   const getSize = () => {
     switch (size) {
       case "small":
@@ -61,7 +61,7 @@ function BoxButton({ size, children, icon, disabled }) {
     }
   };
   return (
-    <ButtonWrapper size={getSize()} disabled={disabled}>
+    <ButtonWrapper size={getSize()} disabled={disabled} onClick={onClick}>
       {icon && <img src={icon} alt="icon" />}
       {children}
     </ButtonWrapper>

--- a/src/components/Modal/CreditRechargeModal.jsx
+++ b/src/components/Modal/CreditRechargeModal.jsx
@@ -1,0 +1,137 @@
+import React, { useState } from "react";
+import styled from "@emotion/styled";
+import closedWindow from "../../assets/btn/close_window.svg";
+import RadioButton from "../RadioButton/RadioButton";
+import icon from "../../assets/icon/white_credit_icon.svg";
+import credit from "../../assets/img/credit.svg";
+import BoxButton from "../BoxButton";
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+const ModalContent = styled.div`
+  color: #f7f7f8;
+  background-color: #181d26;
+  padding: 20px;
+  border-radius: 8px;
+  position: relative;
+  min-width: 300px;
+  max-width: 500px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+`;
+
+const ModalCloseButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+`;
+
+const ModalLabel = styled.h2`
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 21.48px;
+  text-align: left;
+  padding-bottom: 24px;
+`;
+
+const CloseWindow = styled.img`
+  width: 24px;
+  height: 24px;
+`;
+
+const CreditValueWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #02000e;
+  border: 1px solid ${(props) => (props.checked ? "#f96d69" : "#7d7d7d")};
+  width: 295px;
+  height: 62px;
+  gap: 0px;
+  margin-bottom: 8px;
+  padding: 0px 10px;
+  border-radius: 8px;
+  font-size: 20px;
+  font-weight: 700;
+  color: ${(props) => (props.checked ? "#f7f7f8" : "#7d7d7d")};
+  cursor: pointer;
+
+  img {
+    width: 20px;
+  }
+`;
+
+function CreditRechargeModal({ isOpen, onClose }) {
+  const [selectedCredit, setSelectedCredit] = useState(100);
+
+  const creditOptions = [100, 500, 1000, 2000, 9000000]; // 배열에 숫자를 넣으면 많은 값도 충전 가능
+
+  return (
+    <div style={{ textAlign: "center" }}>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalLabel>크레딧 충전하기</ModalLabel>
+        {creditOptions.map((value) => (
+          <CreditOption
+            key={value}
+            value={value}
+            selectedCredit={selectedCredit}
+            onCreditChange={setSelectedCredit}
+          />
+        ))}
+        <div>선택된 금액: {selectedCredit} 크레딧</div>
+        <BoxButton size="modal" icon={icon}>
+          충전하기
+        </BoxButton>
+      </Modal>
+    </div>
+  );
+}
+
+const Modal = ({ isOpen, onClose, children }) => {
+  if (!isOpen) return null;
+
+  return (
+    <ModalOverlay onClick={onClose}>
+      <ModalContent onClick={(e) => e.stopPropagation()}>
+        <ModalCloseButton onClick={onClose}>
+          <CloseWindow src={closedWindow} alt="Close" />
+        </ModalCloseButton>
+        {children}
+      </ModalContent>
+    </ModalOverlay>
+  );
+};
+
+const CreditOption = ({ value, selectedCredit, onCreditChange }) => (
+  <CreditValueWrapper
+    checked={selectedCredit === value}
+    onClick={() => onCreditChange(value)}
+  >
+    <img src={credit} alt="크레딧" />
+    <RadioButton
+      value={value}
+      name="credit"
+      id={`credit-${value}`}
+      checked={selectedCredit === value}
+      onChange={() => onCreditChange(value)}
+    >
+      {value}
+    </RadioButton>
+  </CreditValueWrapper>
+);
+
+export default CreditRechargeModal;

--- a/src/components/Modal/CreditShortageModal.jsx
+++ b/src/components/Modal/CreditShortageModal.jsx
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import styled from "@emotion/styled";
+import closedWindow from "../../assets/btn/close_window.svg";
+import credit from "../../assets/img/credit.svg";
+import BoxButton from "../BoxButton";
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+const ModalContent = styled.div`
+  color: #f7f7f8;
+  background-color: #181d26;
+  padding: 20px;
+  border-radius: 8px;
+  position: relative;
+  min-width: 300px;
+  max-width: 500px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+`;
+
+const ModalCloseButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+`;
+
+const CloseWindow = styled.img`
+  width: 24px;
+  height: 24px;
+`;
+
+const CreditShortageWarning = styled.div`
+  img {
+    width: 113px;
+  }
+  span {
+    color: var(--coralpink);
+  }
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 26px;
+  padding-bottom: 20px;
+`;
+
+function CreditShortageModal() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const handleOpenModal = () => setIsModalOpen(true);
+  const handleCloseModal = () => setIsModalOpen(false);
+
+  return (
+    <div style={{ textAlign: "center" }}>
+      <button onClick={handleOpenModal}>크레딧 부족</button>
+      <Modal isOpen={isModalOpen} onClose={handleCloseModal}>
+        <CreditShortageWarning>
+          <img src={credit} alt="크레딧아이콘" />
+          <p>
+            앗! 투표하기 위한 <span>크레딧</span>이 부족해요
+          </p>
+        </CreditShortageWarning>
+        <BoxButton size="modal" onClick={handleCloseModal}>
+          확인
+        </BoxButton>
+      </Modal>
+    </div>
+  );
+}
+
+const Modal = ({ isOpen, onClose, children }) => {
+  if (!isOpen) return null;
+
+  return (
+    <ModalOverlay onClick={onClose}>
+      <ModalContent onClick={(e) => e.stopPropagation()}>
+        <ModalCloseButton onClick={onClose}>
+          <CloseWindow src={closedWindow} alt="Close" />
+        </ModalCloseButton>
+        {children}
+      </ModalContent>
+    </ModalOverlay>
+  );
+};
+
+export default CreditShortageModal;


### PR DESCRIPTION
## 🧩 #28  <!-- 이슈 번호 입력 -->
- [feature/components/CreditRechargeModal #28 ](이슈 주소)

  <br/>

## 🔎 작업 내용

### 1. jotai 설치로 package.json파일이 바뀌었습니다.

### 2. 충전 모달창 제작하였습니다. (CreditRechargeModal.jsx 파일)
- 충전 모달창의 기본값은 100크레딧 입니다.
- 사용방법
  ![스크린샷 2024-08-30 162709](https://github.com/user-attachments/assets/396723ce-1c72-410b-ada3-c804a7b0268c)
  - 보시면 사용하고 싶은 페이지에서 modal을 껏다, 켰다 할 수 있는 State를 설정해야합니다.
  `const [isRechargeModalOpen, setIsRechargeModalOpen] = useState(false);`
  - 충전 모달창은 isOpen과 onClose를 프롭으로 받습니다.
  - inOpen은 모달창이 켜진 상태를 의미합니다.
  - onClose는 모달창이 닫힌 상태를 의미합니다.
  - 만약 BoxButton과 연결하고 싶다면 BoxButton에 onClick 프롭으로 모달창이 켜진 상태로 만드는 이벤트 핸들러를 만들어 내려주면 됩니다. (위 사진에서는 `handleOpenRechargeModal`)
  - 컴포넌트 내부 81줄 배열에 숫자를 추가하면 충전 크레딧의 값을 추가시킬 수 있습니다.
  - 폼 제출 후 모달창이 닫히는것은 아직 구현하지 않았습니다. 차후 로컬스토리지까지 연결이 되면 구현하도록 하겠습니다.
  - 선택된 금액은 State값을 확인하기 위한 용도로 넣었습니다. 로컬스토리지 연결 되면 삭제하겠습니다.

 <br/>
 <br/>

### 3. 크레딧 부족 경고 모달창 제작하였습니다. (CreditShortageModal.jsx 파일)
- 사용방법
  - 해당 모달창을 띄우고 싶은 위치에 `<CreditShortageModal />` 사용하시면 됩니다.
  - 단순 UI라 생각해서 따로 파라미터를 만들진 않았습니다. 
  - 컴포넌트 내부 보시면 66줄에 `<button onClick={handleOpenModal}>크레딧 부족</button>` 가 있는데, 특수한 상황에서 모달창을 뜨게 할거면 그냥 저거 없애는게 나을 것 같습니다
  - X , 확인 , 모달창 외부를 클릭하면 닫히게 구현하였습니다.

### 4. 크레딧 아이콘, 흰색  파일 추가하였습니다.
![image](https://github.com/user-attachments/assets/a55c1171-bc50-4130-86c4-13200fddf184)

### 5. BoxButton.jsx onClick 프롭 추가하였습니다.
  <br/>

## 동영상 첨부

https://github.com/user-attachments/assets/f1e5c921-1a76-4d38-b476-40afd19e0393


<br/>

## 🔧 앞으로의 과제

- 충전 모달창 내부의 상태값을 jotai를 사용하여 로컬스토리지로 전달



## 👩‍💻 공유 포인트 및 논의 사항

따로 반응형은 설정하지 않았습니다. 보니까 어디든 너비값이 항상 고정이더라구용


<!-- 공유하거나 논의할 사항을 작성해주세요. -->
